### PR TITLE
[errorfix] css수정- 컨텐츠에 따른 카드 넓이즈의 변동이 없도록 수정

### DIFF
--- a/src/components/organisms/AddNewDailyData/index.tsx
+++ b/src/components/organisms/AddNewDailyData/index.tsx
@@ -153,7 +153,8 @@ const styles = {
   wrap: css`
     padding: 0 15px;
     ${mediaQueries("md")} {
-      width: calc(50% - 5px);
+      width: calc(50% - 15px);
+      box-sizing: border-box;
     }
   `,
   title: css`

--- a/src/components/organisms/DailyDatasList/index.tsx
+++ b/src/components/organisms/DailyDatasList/index.tsx
@@ -113,7 +113,8 @@ const styles = {
     background-color: ${COLORS.GRAY[1]};
     ${mediaQueries("md")} {
       padding-top: 0;
-      width: calc(50% - 5px);
+      width: calc(50% - 15px);
+      box-sizing: border-box;
       border-left: 1px dashed ${COLORS.CADET_BLUE};
       background-color: transparent;
     }


### PR DESCRIPTION
컨텐츠 길이에 따라 카드의 넓이가 변경이 되어 전체적인 레이아웃에 영향을 끼쳤다.
컨텐츠 길이에 따라 변동이 일어나지 않도록 css수정