### PR TITLE
fix - 삭제 기능 버그 개선

### DIFF
--- a/src/components/organisms/AddNewDailyData/index.tsx
+++ b/src/components/organisms/AddNewDailyData/index.tsx
@@ -12,12 +12,13 @@ import moment from "moment";
 
 interface PropTypes {
   _css?: SerializedStyles | SerializedStyles[];
+  sortingArr: DailyDataItemType[];
 }
 
-export const AddNewDailyData: FC<PropTypes> = ({ _css }) => {
-  const { dailyDatas, setDailyDatas } = useDailyDatas();
-  let lastId = dailyDatas.length ? dailyDatas[dailyDatas.length - 1].id : 0;
-  let [nextId] = useState(() => (dailyDatas.length > 0 ? lastId + 1 : 0));
+export const AddNewDailyData: FC<PropTypes> = ({ _css, sortingArr }) => {
+  const { setDailyDatas } = useDailyDatas();
+  let lastId = sortingArr.length ? sortingArr[sortingArr.length - 1].id : 0;
+  let [nextId] = useState(() => (sortingArr.length > 0 ? lastId + 1 : 0));
 
   const [inputError, setInputError] = useState(false);
   const [today] = useState(moment());
@@ -64,14 +65,14 @@ export const AddNewDailyData: FC<PropTypes> = ({ _css }) => {
       event.preventDefault();
       setInputError(true);
     } else {
-      setDailyDatas(dailyDatas.concat(inputData));
+      setDailyDatas(sortingArr.concat(inputData));
       resetInputs();
     }
   };
 
   useEffect(() => {
-    window.localStorage.setItem("dailyDatas", JSON.stringify(dailyDatas));
-  }, [dailyDatas]);
+    window.localStorage.setItem("dailyDatas", JSON.stringify(sortingArr));
+  }, [sortingArr]);
 
   const handleChange = (
     event: ChangeEvent<HTMLInputElement | HTMLSelectElement>

--- a/src/components/organisms/DailyDatasList/index.tsx
+++ b/src/components/organisms/DailyDatasList/index.tsx
@@ -13,12 +13,18 @@ import { tagType } from "@/helpers/common/DataTypes";
 interface PropTypes {
   _css?: SerializedStyles | SerializedStyles[];
   keyword: string;
+  sortingArr: DailyDataItemType[];
+  setSortingArr: React.Dispatch<React.SetStateAction<DailyDataItemType[]>>;
 }
 
-export const DailyDatasList: FC<PropTypes> = ({ _css, keyword }) => {
+export const DailyDatasList: FC<PropTypes> = ({
+  _css,
+  keyword,
+  sortingArr,
+  setSortingArr,
+}) => {
   const [mounted, setMounted] = useState<boolean>(false);
   const { dailyDatas } = useDailyDatas();
-  const [sortingArr, setSortingArr] = useState<DailyDataItemType[]>(dailyDatas);
   let [isArray, setIsArray] = useState(false);
   const isLoaded = !!Object.keys(dailyDatas).length;
   useEffect(() => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,11 +6,15 @@ import { COLORS } from "@/styles/variables/Colors";
 import { AddNewDailyData } from "@/components/organisms/AddNewDailyData";
 import { SearchDailyDatas } from "@/components/organisms/SearchDailyDatas";
 import { DailyDatasList } from "@/components/organisms/DailyDatasList";
+import { useDailyDatas } from "@/helpers/hooks/useDailyDatas";
 import Centering from "@/components/templates/Centering";
+import { DailyDataItemType } from "@/helpers/common/DataTypes";
 
 export default function Home() {
   type keywordType = string;
+  const { dailyDatas } = useDailyDatas();
   const [keyword, setKeyword] = useState<keywordType>("");
+  const [sortingArr, setSortingArr] = useState<DailyDataItemType[]>(dailyDatas);
 
   return (
     <>
@@ -24,8 +28,12 @@ export default function Home() {
         <SearchDailyDatas keyword={keyword} setKeyword={setKeyword} />
         <Centering _css={styles.mqCentering}>
           <div css={styles.mqWrap}>
-            <AddNewDailyData />
-            <DailyDatasList keyword={keyword} />
+            <AddNewDailyData sortingArr={sortingArr} />
+            <DailyDatasList
+              keyword={keyword}
+              sortingArr={sortingArr}
+              setSortingArr={setSortingArr}
+            />
           </div>
         </Centering>
       </main>


### PR DESCRIPTION
## PR내용
삭제 버튼을 누른 후 브라우저 리로드를 하지 않은 상태로 데이터를 추가했을 때
삭제한 데이터가 남아있는 상태로 새로운 데이터가 추가되는 버그 대응

**버그 재연 예시(순서)** 
1. {제목: 'A', 내용: 'A'}, {제목: '1', 내용: '1'}인 데이터를 추가한다.
2. {제목: 'A', 내용: 'A'} 인 데이터를 삭제한다.
3. 새로운 데이터 {제목: '2', 내용: '2'} 를 등록한다.
4. 카드 리스트에 우측 데이터처럼 보여진다.→ [{제목: 'A', 내용: 'A'}, {제목: '1', 내용: '1'}, {제목: '2', 내용: '2'}]

#### PR타입(하나 이상의 PR타입에 체크✅)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [ ] release

#### PR작성 목적
삭제 기능 버그 개선

#### 완료조건
- [x] 콘솔 에러가 발생하지 않았다.
- [x] 데이터를 삭제한 후 새로운 데이터를 등록했을 때 삭제한 데이터는 지워진 상태로 새로운 데이터가 등록된다.

## Brach

#### 반영 (merge)브랜치 (해당하는 브랜치에 체크✅ 혹은 기재)

- [ ] main
- [x] develop
- [ ] 기타-브랜치명:

## 참고사항
